### PR TITLE
v0.1.7

### DIFF
--- a/cmd/simult-server/main.go
+++ b/cmd/simult-server/main.go
@@ -83,7 +83,7 @@ func configReload(configFilename string) bool {
 	}
 	if app != nil {
 		app.Close()
-		lb.PromReset()
+		//lb.PromReset()
 	}
 	app = an
 	configGlobal(cfg)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/simult/server
 go 1.11
 
 require (
-	github.com/orkunkaraduman/go-accepter v1.2.0
+	github.com/orkunkaraduman/go-accepter v1.2.1
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v1.1.0
 	gopkg.in/yaml.v3 v3.0.0-20190924164351-c8b7dadae555

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/orkunkaraduman/go-accepter v1.2.0 h1:EDvFB9bTKDl1fQi3kj47SsIh1nEEfHjEflhAATWb458=
 github.com/orkunkaraduman/go-accepter v1.2.0/go.mod h1:qxPaCy06P9pjDS2bSg5Q5h5yqsy1nIvJVXsiJGW8sOE=
+github.com/orkunkaraduman/go-accepter v1.2.1 h1:fHn0lBXeE63qokdAc8BZH1lQtCmq/B85d30WIyAaNDI=
+github.com/orkunkaraduman/go-accepter v1.2.1/go.mod h1:qxPaCy06P9pjDS2bSg5Q5h5yqsy1nIvJVXsiJGW8sOE=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/pkg/lb/backendserver.go
+++ b/pkg/lb/backendserver.go
@@ -98,6 +98,13 @@ func (bs *backendServer) Close() {
 	bs.healthCheckMu.Unlock()
 }
 
+func (bs *backendServer) IsShared() bool {
+	bs.sharedMu.Lock()
+	r := bs.shared
+	bs.sharedMu.Unlock()
+	return r
+}
+
 func (bs *backendServer) SetShared(status bool) bool {
 	bs.sharedMu.Lock()
 	r := bs.shared

--- a/pkg/lb/httpbackend.go
+++ b/pkg/lb/httpbackend.go
@@ -517,21 +517,21 @@ func (b *HTTPBackend) serve(ctx context.Context, reqDesc *httpReqDesc) (err erro
 	b.promReadBytes.With(promLabels).Add(float64(r))
 	b.promWriteBytes.With(promLabels).Add(float64(w))
 	if e := errors.Cause(err); e != errGracefulTermination {
-		errDesc := ""
+		//errDesc := ""
 		if e != nil && e != errExpectedEOF {
-			if e, ok := e.(*httpError); ok {
+			/*if e, ok := e.(*httpError); ok {
 				errDesc = e.Group
 			} else {
 				errDesc = "unknown"
 				debugLogger.Printf("unknown error on backend server %q on backend %q. may be it is a bug: %v", bs.server, b.opts.Name, err)
-			}
+			}*/
 		} else {
-			b.promRequestDurationSeconds.With(promLabels).Observe(time.Now().Sub(startTime).Seconds())
+			//b.promRequestDurationSeconds.With(promLabels).Observe(time.Now().Sub(startTime).Seconds())
 			if tm := reqDesc.beConn.TimeToFirstByte(); !tm.IsZero() {
 				b.promTimeToFirstByteSeconds.With(promLabels).Observe(tm.Sub(startTime).Seconds())
 			}
 		}
-		b.promRequestsTotal.MustCurryWith(promLabels).With(prometheus.Labels{"error": errDesc}).Inc()
+		//b.promRequestsTotal.MustCurryWith(promLabels).With(prometheus.Labels{"error": errDesc}).Inc()
 	}
 
 	return

--- a/pkg/lb/httpbackend.go
+++ b/pkg/lb/httpbackend.go
@@ -523,6 +523,7 @@ func (b *HTTPBackend) serve(ctx context.Context, reqDesc *httpReqDesc) (err erro
 				errDesc = e.Group
 			} else {
 				errDesc = "unknown"
+				debugLogger.Printf("unknown error on backend server %q on backend %q. may be it is a bug: %v", bs.server, b.opts.Name, err)
 			}
 		} else {
 			b.promRequestDurationSeconds.With(promLabels).Observe(time.Now().Sub(startTime).Seconds())

--- a/pkg/lb/httpbackend.go
+++ b/pkg/lb/httpbackend.go
@@ -55,6 +55,7 @@ type HTTPBackend struct {
 	promRequestDurationSeconds prometheus.ObserverVec
 	promTimeToFirstByteSeconds prometheus.ObserverVec
 	promActiveConnections      *prometheus.GaugeVec
+	promServerHealthy          *prometheus.GaugeVec
 }
 
 func NewHTTPBackend(opts HTTPBackendOptions) (b *HTTPBackend, err error) {
@@ -72,8 +73,6 @@ func (b *HTTPBackend) Fork(opts HTTPBackendOptions) (bn *HTTPBackend, err error)
 	bn.bss = make(map[string]*backendServer, len(opts.Servers))
 	bn.rnd = rand.New(rand.NewSource(time.Now().Unix()))
 
-	bn.updateBssList()
-
 	promLabels := map[string]string{
 		"backend": bn.opts.Name,
 	}
@@ -83,6 +82,9 @@ func (b *HTTPBackend) Fork(opts HTTPBackendOptions) (bn *HTTPBackend, err error)
 	bn.promRequestDurationSeconds = promHTTPBackendRequestDurationSeconds.MustCurryWith(promLabels)
 	bn.promTimeToFirstByteSeconds = promHTTPBackendTimeToFirstByteSeconds.MustCurryWith(promLabels)
 	bn.promActiveConnections = promHTTPBackendActiveConnections.MustCurryWith(promLabels)
+	bn.promServerHealthy = promHTTPBackendServerHealthy.MustCurryWith(promLabels)
+
+	bn.updateBssList()
 
 	defer func() {
 		if err == nil {
@@ -177,7 +179,13 @@ func (b *HTTPBackend) updateBssList() {
 	serverList := make([]*backendServer, 0, len(b.bss))
 	for _, bsr := range b.bss {
 		if !bsr.Healthy() {
+			if !bsr.IsShared() {
+				b.promServerHealthy.With(prometheus.Labels{"server": bsr.server}).Set(0)
+			}
 			continue
+		}
+		if !bsr.IsShared() {
+			b.promServerHealthy.With(prometheus.Labels{"server": bsr.server}).Set(1)
 		}
 		serverList = append(serverList, bsr)
 	}
@@ -391,7 +399,7 @@ func (b *HTTPBackend) serve(ctx context.Context, reqDesc *httpReqDesc) (err erro
 		}
 		err = errors.WithStack(e)
 		e.PrintDebugLog()
-		reqDesc.feConn.Write([]byte("HTTP/1.0 503 Service Unavailable\r\n\r\n"))
+		reqDesc.feConn.Write([]byte(httpServiceUnavailable))
 		return
 	}
 	reqDesc.beServer = bs
@@ -406,7 +414,7 @@ func (b *HTTPBackend) serve(ctx context.Context, reqDesc *httpReqDesc) (err erro
 		}
 		err = errors.WithStack(e)
 		e.PrintDebugLog()
-		reqDesc.feConn.Write([]byte("HTTP/1.0 503 Service Unavailable\r\n\r\n"))
+		reqDesc.feConn.Write([]byte(httpBadGateway))
 		return
 	}
 	defer func() {

--- a/pkg/lb/httpcommon.go
+++ b/pkg/lb/httpcommon.go
@@ -12,6 +12,13 @@ import (
 	"github.com/pkg/errors"
 )
 
+var (
+	httpBadRequest         = "HTTP/1.0 400 Bad Request\r\n\r\nBad Request\r\n"
+	httpForbidden          = "HTTP/1.0 403 Forbidden\r\n\r\nForbidden\r\n"
+	httpBadGateway         = "HTTP/1.0 502 Bad Gateway\r\n\r\nBad Gateway\r\n"
+	httpServiceUnavailable = "HTTP/1.0 503 Service Unavailable\r\n\r\nService Unavailable\r\n"
+)
+
 type httpError struct {
 	Cause error
 	Group string

--- a/pkg/lb/httpfrontend.go
+++ b/pkg/lb/httpfrontend.go
@@ -84,13 +84,13 @@ type HTTPFrontend struct {
 	workerCtxCancel context.CancelFunc
 	workerWg        sync.WaitGroup
 
-	promReadBytes              *prometheus.CounterVec
-	promWriteBytes             *prometheus.CounterVec
-	promRequestsTotal          *prometheus.CounterVec
-	promRequestDurationSeconds prometheus.ObserverVec
-	promActiveConnections      *prometheus.GaugeVec
-	promIdleConnections        *prometheus.GaugeVec
-	promRestrictedTotal        *prometheus.CounterVec
+	promReadBytes               *prometheus.CounterVec
+	promWriteBytes              *prometheus.CounterVec
+	promRequestsTotal           *prometheus.CounterVec
+	promRequestDurationSeconds  prometheus.ObserverVec
+	promActiveConnections       *prometheus.GaugeVec
+	promIdleConnections         *prometheus.GaugeVec
+	promRestrictedRequestsTotal *prometheus.CounterVec
 }
 
 func NewHTTPFrontend(opts HTTPFrontendOptions) (f *HTTPFrontend, err error) {
@@ -115,7 +115,7 @@ func (f *HTTPFrontend) Fork(opts HTTPFrontendOptions) (fn *HTTPFrontend, err err
 	fn.promRequestDurationSeconds = promHTTPFrontendRequestDurationSeconds.MustCurryWith(promLabels)
 	fn.promActiveConnections = promHTTPFrontendActiveConnections.MustCurryWith(promLabels)
 	fn.promIdleConnections = promHTTPFrontendIdleConnections.MustCurryWith(promLabels)
-	fn.promRestrictedTotal = promHTTPFrontendRestrictedTotal.MustCurryWith(promLabels)
+	fn.promRestrictedRequestsTotal = promHTTPFrontendRestrictedRequestsTotal.MustCurryWith(promLabels)
 
 	defer func() {
 		if err == nil {
@@ -256,7 +256,7 @@ func (f *HTTPFrontend) serveAsync(ctx context.Context, errCh chan<- error, reqDe
 			"path":    reqDesc.fePath,
 			"method":  reqDesc.feStatusMethod,
 		}
-		f.promRestrictedTotal.With(promLabels).Inc()
+		f.promRestrictedRequestsTotal.With(promLabels).Inc()
 		err = errors.WithStack(errGracefulTermination)
 		reqDesc.feConn.Write([]byte(httpForbidden))
 		return

--- a/pkg/lb/httpfrontend.go
+++ b/pkg/lb/httpfrontend.go
@@ -322,6 +322,7 @@ func (f *HTTPFrontend) serve(ctx context.Context, reqDesc *httpReqDesc) (err err
 				errDesc = e.Group
 			} else {
 				errDesc = "unknown"
+				debugLogger.Printf("unknown error on listener %q on frontend %q. may be it is a bug: %v", reqDesc.feConn.LocalAddr().String(), f.opts.Name, err)
 			}
 		} else {
 			f.promRequestDurationSeconds.With(promLabels).Observe(time.Now().Sub(startTime).Seconds())

--- a/pkg/lb/listener.go
+++ b/pkg/lb/listener.go
@@ -82,8 +82,8 @@ func (l *Listener) Close() {
 	if l.accr != nil {
 		if !l.accr.Handler.(*accepterHandler).SetShared(false) {
 			l.accr.Close()
-			l.accr = nil
 		}
+		l.accr = nil
 	}
 	l.accrMu.Unlock()
 	return

--- a/pkg/lb/prom.go
+++ b/pkg/lb/prom.go
@@ -21,6 +21,7 @@ var (
 	promHTTPBackendRequestDurationSeconds  *prometheus.HistogramVec
 	promHTTPBackendTimeToFirstByteSeconds  *prometheus.HistogramVec
 	promHTTPBackendActiveConnections       *prometheus.GaugeVec
+	promHTTPBackendServerHealthy           *prometheus.GaugeVec
 )
 
 func PromInitialize(namespace string) {
@@ -109,6 +110,12 @@ func PromInitialize(namespace string) {
 		Subsystem: "http_backend",
 		Name:      "active_connections",
 	}, []string{"backend", "server"})
+
+	promHTTPBackendServerHealthy = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Subsystem: "http_backend",
+		Name:      "server_healthy",
+	}, []string{"backend", "server"})
 }
 
 func PromReset() {
@@ -124,4 +131,5 @@ func PromReset() {
 	promHTTPBackendRequestDurationSeconds.Reset()
 	promHTTPBackendTimeToFirstByteSeconds.Reset()
 	//promHTTPBackendActiveConnections.Reset()
+	//promHTTPBackendServerHealthy.Reset()
 }

--- a/pkg/lb/prom.go
+++ b/pkg/lb/prom.go
@@ -8,22 +8,21 @@ import (
 )
 
 var (
-	promInitialized                         uint32
-	promHTTPFrontendReadBytes               *prometheus.CounterVec
-	promHTTPFrontendWriteBytes              *prometheus.CounterVec
-	promHTTPFrontendRequestsTotal           *prometheus.CounterVec
-	promHTTPFrontendRequestDurationSeconds  *prometheus.HistogramVec
-	promHTTPFrontendActiveConnections       *prometheus.GaugeVec
-	promHTTPFrontendIdleConnections         *prometheus.GaugeVec
-	promHTTPFrontendRestrictedRequestsTotal *prometheus.CounterVec
-	promHTTPBackendReadBytes                *prometheus.CounterVec
-	promHTTPBackendWriteBytes               *prometheus.CounterVec
-	promHTTPBackendRequestsTotal            *prometheus.CounterVec
-	promHTTPBackendRequestDurationSeconds   *prometheus.HistogramVec
-	promHTTPBackendTimeToFirstByteSeconds   *prometheus.HistogramVec
-	promHTTPBackendActiveConnections        *prometheus.GaugeVec
-	promHTTPBackendServerHealthy            *prometheus.GaugeVec
-	promListenerTemporaryErrorsTotal        *prometheus.CounterVec
+	promInitialized                        uint32
+	promHTTPFrontendReadBytes              *prometheus.CounterVec
+	promHTTPFrontendWriteBytes             *prometheus.CounterVec
+	promHTTPFrontendRequestsTotal          *prometheus.CounterVec
+	promHTTPFrontendRequestDurationSeconds *prometheus.HistogramVec
+	promHTTPFrontendActiveConnections      *prometheus.GaugeVec
+	promHTTPFrontendIdleConnections        *prometheus.GaugeVec
+	promHTTPBackendReadBytes               *prometheus.CounterVec
+	promHTTPBackendWriteBytes              *prometheus.CounterVec
+	promHTTPBackendRequestsTotal           *prometheus.CounterVec
+	promHTTPBackendRequestDurationSeconds  *prometheus.HistogramVec
+	promHTTPBackendTimeToFirstByteSeconds  *prometheus.HistogramVec
+	promHTTPBackendActiveConnections       *prometheus.GaugeVec
+	promHTTPBackendServerHealthy           *prometheus.GaugeVec
+	promListenerTemporaryErrorsTotal       *prometheus.CounterVec
 )
 
 func PromInitialize(namespace string) {
@@ -74,12 +73,6 @@ func PromInitialize(namespace string) {
 		Subsystem: "http_frontend",
 		Name:      "idle_connections",
 	}, []string{"frontend", "address"})
-
-	promHTTPFrontendRestrictedRequestsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
-		Namespace: namespace,
-		Subsystem: "http_frontend",
-		Name:      "restricted_requests_total",
-	}, []string{"frontend", "address", "host", "path", "method"})
 
 	promHTTPBackendReadBytes = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: namespace,
@@ -139,7 +132,6 @@ func PromReset() {
 	promHTTPFrontendRequestDurationSeconds.Reset()
 	//promHTTPFrontendActiveConnections.Reset()
 	//promHTTPFrontendIdleConnections.Reset()
-	promHTTPFrontendRestrictedRequestsTotal.Reset()
 	promHTTPBackendReadBytes.Reset()
 	promHTTPBackendWriteBytes.Reset()
 	promHTTPBackendRequestsTotal.Reset()

--- a/pkg/lb/prom.go
+++ b/pkg/lb/prom.go
@@ -15,6 +15,7 @@ var (
 	promHTTPFrontendRequestDurationSeconds *prometheus.HistogramVec
 	promHTTPFrontendActiveConnections      *prometheus.GaugeVec
 	promHTTPFrontendIdleConnections        *prometheus.GaugeVec
+	promHTTPFrontendRestrictedTotal        *prometheus.CounterVec
 	promHTTPBackendReadBytes               *prometheus.CounterVec
 	promHTTPBackendWriteBytes              *prometheus.CounterVec
 	promHTTPBackendRequestsTotal           *prometheus.CounterVec
@@ -73,6 +74,12 @@ func PromInitialize(namespace string) {
 		Name:      "idle_connections",
 	}, []string{"frontend", "address"})
 
+	promHTTPFrontendRestrictedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: namespace,
+		Subsystem: "http_frontend",
+		Name:      "restricted_total",
+	}, []string{"frontend", "address", "host", "path", "method"})
+
 	promHTTPBackendReadBytes = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: namespace,
 		Subsystem: "http_backend",
@@ -125,6 +132,7 @@ func PromReset() {
 	promHTTPFrontendRequestDurationSeconds.Reset()
 	//promHTTPFrontendActiveConnections.Reset()
 	//promHTTPFrontendIdleConnections.Reset()
+	promHTTPFrontendRestrictedTotal.Reset()
 	promHTTPBackendReadBytes.Reset()
 	promHTTPBackendWriteBytes.Reset()
 	promHTTPBackendRequestsTotal.Reset()

--- a/pkg/lb/prom.go
+++ b/pkg/lb/prom.go
@@ -23,6 +23,7 @@ var (
 	promHTTPBackendTimeToFirstByteSeconds   *prometheus.HistogramVec
 	promHTTPBackendActiveConnections        *prometheus.GaugeVec
 	promHTTPBackendServerHealthy            *prometheus.GaugeVec
+	promListenerTemporaryErrorsTotal        *prometheus.CounterVec
 )
 
 func PromInitialize(namespace string) {
@@ -123,6 +124,12 @@ func PromInitialize(namespace string) {
 		Subsystem: "http_backend",
 		Name:      "server_healthy",
 	}, []string{"backend", "server"})
+
+	promListenerTemporaryErrorsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: namespace,
+		Subsystem: "listener",
+		Name:      "temporary_errors_total",
+	}, []string{"network", "address"})
 }
 
 func PromReset() {
@@ -140,4 +147,5 @@ func PromReset() {
 	promHTTPBackendTimeToFirstByteSeconds.Reset()
 	//promHTTPBackendActiveConnections.Reset()
 	//promHTTPBackendServerHealthy.Reset()
+	promListenerTemporaryErrorsTotal.Reset()
 }

--- a/pkg/lb/prom.go
+++ b/pkg/lb/prom.go
@@ -8,21 +8,21 @@ import (
 )
 
 var (
-	promInitialized                        uint32
-	promHTTPFrontendReadBytes              *prometheus.CounterVec
-	promHTTPFrontendWriteBytes             *prometheus.CounterVec
-	promHTTPFrontendRequestsTotal          *prometheus.CounterVec
-	promHTTPFrontendRequestDurationSeconds *prometheus.HistogramVec
-	promHTTPFrontendActiveConnections      *prometheus.GaugeVec
-	promHTTPFrontendIdleConnections        *prometheus.GaugeVec
-	promHTTPFrontendRestrictedTotal        *prometheus.CounterVec
-	promHTTPBackendReadBytes               *prometheus.CounterVec
-	promHTTPBackendWriteBytes              *prometheus.CounterVec
-	promHTTPBackendRequestsTotal           *prometheus.CounterVec
-	promHTTPBackendRequestDurationSeconds  *prometheus.HistogramVec
-	promHTTPBackendTimeToFirstByteSeconds  *prometheus.HistogramVec
-	promHTTPBackendActiveConnections       *prometheus.GaugeVec
-	promHTTPBackendServerHealthy           *prometheus.GaugeVec
+	promInitialized                         uint32
+	promHTTPFrontendReadBytes               *prometheus.CounterVec
+	promHTTPFrontendWriteBytes              *prometheus.CounterVec
+	promHTTPFrontendRequestsTotal           *prometheus.CounterVec
+	promHTTPFrontendRequestDurationSeconds  *prometheus.HistogramVec
+	promHTTPFrontendActiveConnections       *prometheus.GaugeVec
+	promHTTPFrontendIdleConnections         *prometheus.GaugeVec
+	promHTTPFrontendRestrictedRequestsTotal *prometheus.CounterVec
+	promHTTPBackendReadBytes                *prometheus.CounterVec
+	promHTTPBackendWriteBytes               *prometheus.CounterVec
+	promHTTPBackendRequestsTotal            *prometheus.CounterVec
+	promHTTPBackendRequestDurationSeconds   *prometheus.HistogramVec
+	promHTTPBackendTimeToFirstByteSeconds   *prometheus.HistogramVec
+	promHTTPBackendActiveConnections        *prometheus.GaugeVec
+	promHTTPBackendServerHealthy            *prometheus.GaugeVec
 )
 
 func PromInitialize(namespace string) {
@@ -74,10 +74,10 @@ func PromInitialize(namespace string) {
 		Name:      "idle_connections",
 	}, []string{"frontend", "address"})
 
-	promHTTPFrontendRestrictedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	promHTTPFrontendRestrictedRequestsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: namespace,
 		Subsystem: "http_frontend",
-		Name:      "restricted_total",
+		Name:      "restricted_requests_total",
 	}, []string{"frontend", "address", "host", "path", "method"})
 
 	promHTTPBackendReadBytes = promauto.NewCounterVec(prometheus.CounterOpts{
@@ -132,7 +132,7 @@ func PromReset() {
 	promHTTPFrontendRequestDurationSeconds.Reset()
 	//promHTTPFrontendActiveConnections.Reset()
 	//promHTTPFrontendIdleConnections.Reset()
-	promHTTPFrontendRestrictedTotal.Reset()
+	promHTTPFrontendRestrictedRequestsTotal.Reset()
 	promHTTPBackendReadBytes.Reset()
 	promHTTPBackendWriteBytes.Reset()
 	promHTTPBackendRequestsTotal.Reset()


### PR DESCRIPTION
- backend names can be empty-string. this requests will restrict when it happens.
- prom metrics will not reset when config reload. because this situation leaks metrics.
- added promHTTPBackendServerHealthy gauge metric.
- disabled promHTTPBackendRequestsTotal and promHTTPBackendRequestDurationSeconds metrics. because they had duplicate data and decrease performance.
- added promListenerTemporaryErrorsTotal metrics for catching temporary socket accept errors.
- set * to host and path when using default backend.
- added varaibles (eg. httpBadRequest) for http error responses.