### PR TITLE
v0.1.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,9 @@
 module github.com/simult/server
 
-go 1.11
+go 1.13
 
 require (
 	github.com/orkunkaraduman/go-accepter v1.2.1
-	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v1.1.0
 	gopkg.in/yaml.v3 v3.0.0-20190924164351-c8b7dadae555
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/simult/server
 go 1.13
 
 require (
-	github.com/orkunkaraduman/go-accepter v1.2.1
+	github.com/orkunkaraduman/go-accepter v1.2.2
 	github.com/prometheus/client_golang v1.1.0
 	gopkg.in/yaml.v3 v3.0.0-20190924164351-c8b7dadae555
 )

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/orkunkaraduman/go-accepter v1.2.0 h1:EDvFB9bTKDl1fQi3kj47SsIh1nEEfHjE
 github.com/orkunkaraduman/go-accepter v1.2.0/go.mod h1:qxPaCy06P9pjDS2bSg5Q5h5yqsy1nIvJVXsiJGW8sOE=
 github.com/orkunkaraduman/go-accepter v1.2.1 h1:fHn0lBXeE63qokdAc8BZH1lQtCmq/B85d30WIyAaNDI=
 github.com/orkunkaraduman/go-accepter v1.2.1/go.mod h1:qxPaCy06P9pjDS2bSg5Q5h5yqsy1nIvJVXsiJGW8sOE=
+github.com/orkunkaraduman/go-accepter v1.2.2 h1:zHZpRv/rABe+Bqid+Go0F39KbzdA6Dbv3DN5ZbfHdEo=
+github.com/orkunkaraduman/go-accepter v1.2.2/go.mod h1:qxPaCy06P9pjDS2bSg5Q5h5yqsy1nIvJVXsiJGW8sOE=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/pkg/config/app.go
+++ b/pkg/config/app.go
@@ -115,7 +115,7 @@ func (a *App) Fork(cfg *Config) (an *App, err error) {
 		}
 		bn, err = b.Fork(opts)
 		if err != nil {
-			err = fmt.Errorf("backend %q error: %v", name, err)
+			err = fmt.Errorf("backend %q error: %w", name, err)
 			return
 		}
 		an.backends[name] = bn
@@ -166,7 +166,7 @@ func (a *App) Fork(cfg *Config) (an *App, err error) {
 				if restriction.Network != "" {
 					_, newRestriction.Network, err = net.ParseCIDR(restriction.Network)
 					if err != nil {
-						err = fmt.Errorf("frontend %q route restriction network %q parse error: %v", name, restriction.Network, err)
+						err = fmt.Errorf("frontend %q route restriction network %q parse error: %w", name, restriction.Network, err)
 						return
 					}
 				}
@@ -184,7 +184,7 @@ func (a *App) Fork(cfg *Config) (an *App, err error) {
 		}
 		fn, err = f.Fork(opts)
 		if err != nil {
-			err = fmt.Errorf("frontend %q error: %v", name, err)
+			err = fmt.Errorf("frontend %q error: %w", name, err)
 			return
 		}
 		an.frontends[name] = fn
@@ -216,7 +216,7 @@ func (a *App) Fork(cfg *Config) (an *App, err error) {
 				}
 				opts.TLSConfig, err = tlsParams.Config()
 				if err != nil {
-					err = fmt.Errorf("frontend %q listener %q tls error: %v", name, lName, err)
+					err = fmt.Errorf("frontend %q listener %q tls error: %w", name, lName, err)
 					return
 				}
 			}
@@ -227,7 +227,7 @@ func (a *App) Fork(cfg *Config) (an *App, err error) {
 			}
 			ln, err = l.Fork(opts)
 			if err != nil {
-				err = fmt.Errorf("frontend %q listener %q error: %v", name, lName, err)
+				err = fmt.Errorf("frontend %q listener %q error: %w", name, lName, err)
 				return
 			}
 			an.listeners[lName] = ln

--- a/pkg/config/app.go
+++ b/pkg/config/app.go
@@ -1,11 +1,11 @@
 package config
 
 import (
+	"fmt"
 	"net"
 	"net/http"
 	"sync"
 
-	"github.com/pkg/errors"
 	"github.com/simult/server/pkg/hc"
 	"github.com/simult/server/pkg/lb"
 )
@@ -46,17 +46,17 @@ func (a *App) Fork(cfg *Config) (an *App, err error) {
 
 	for name, item := range cfg.HealthChecks {
 		if name == "" || !nameRgx.MatchString(name) {
-			err = errors.Errorf("healthcheck %q has not a valid name", name)
+			err = fmt.Errorf("healthcheck %q has not a valid name", name)
 			return
 		}
 		if _, ok := an.healthChecks[name]; ok {
-			err = errors.Errorf("healthcheck %q already defined", name)
+			err = fmt.Errorf("healthcheck %q already defined", name)
 			return
 		}
 		var h interface{}
 		if item.HTTP != nil {
 			if h != nil {
-				err = errors.Errorf("healthcheck %q another healthcheck defined", name)
+				err = fmt.Errorf("healthcheck %q another healthcheck defined", name)
 				return
 			}
 			respBody := []byte(nil)
@@ -80,11 +80,11 @@ func (a *App) Fork(cfg *Config) (an *App, err error) {
 
 	for name, item := range cfg.Backends {
 		if name == "" || !nameRgx.MatchString(name) {
-			err = errors.Errorf("backend %q has not a valid name", name)
+			err = fmt.Errorf("backend %q has not a valid name", name)
 			return
 		}
 		if _, ok := an.backends[name]; ok {
-			err = errors.Errorf("backend %q already defined", name)
+			err = fmt.Errorf("backend %q already defined", name)
 			return
 		}
 		var opts lb.HTTPBackendOptions
@@ -99,7 +99,7 @@ func (a *App) Fork(cfg *Config) (an *App, err error) {
 		if item.HealthCheck != "" {
 			h, ok := an.healthChecks[item.HealthCheck]
 			if !ok {
-				err = errors.Errorf("backend %q healthcheck %q not found", name, item.HealthCheck)
+				err = fmt.Errorf("backend %q healthcheck %q not found", name, item.HealthCheck)
 				return
 			}
 			switch h.(type) {
@@ -115,7 +115,7 @@ func (a *App) Fork(cfg *Config) (an *App, err error) {
 		}
 		bn, err = b.Fork(opts)
 		if err != nil {
-			err = errors.Errorf("backend %q error: %v", name, err)
+			err = fmt.Errorf("backend %q error: %v", name, err)
 			return
 		}
 		an.backends[name] = bn
@@ -124,11 +124,11 @@ func (a *App) Fork(cfg *Config) (an *App, err error) {
 
 	for name, item := range cfg.Frontends {
 		if name == "" || !nameRgx.MatchString(name) {
-			err = errors.Errorf("frontend %q has not a valid name", name)
+			err = fmt.Errorf("frontend %q has not a valid name", name)
 			return
 		}
 		if _, ok := an.frontends[name]; ok {
-			err = errors.Errorf("frontend %q already defined", name)
+			err = fmt.Errorf("frontend %q already defined", name)
 			return
 		}
 		var opts lb.HTTPFrontendOptions
@@ -144,7 +144,7 @@ func (a *App) Fork(cfg *Config) (an *App, err error) {
 		if item.DefaultBackend != "" {
 			opts.DefaultBackend = an.backends[item.DefaultBackend]
 			if opts.DefaultBackend == nil {
-				err = errors.Errorf("frontend %q defaultbackend %q not found", name, item.DefaultBackend)
+				err = fmt.Errorf("frontend %q defaultbackend %q not found", name, item.DefaultBackend)
 				return
 			}
 		}
@@ -156,7 +156,7 @@ func (a *App) Fork(cfg *Config) (an *App, err error) {
 			if route.Backend != "" {
 				newRoute.Backend = an.backends[route.Backend]
 				if newRoute.Backend == nil {
-					err = errors.Errorf("frontend %q route error: backend %q not found", name, route.Backend)
+					err = fmt.Errorf("frontend %q route error: backend %q not found", name, route.Backend)
 					return
 				}
 			}
@@ -166,7 +166,7 @@ func (a *App) Fork(cfg *Config) (an *App, err error) {
 				if restriction.Network != "" {
 					_, newRestriction.Network, err = net.ParseCIDR(restriction.Network)
 					if err != nil {
-						err = errors.Errorf("frontend %q route restriction network %q parse error: %v", name, restriction.Network, err)
+						err = fmt.Errorf("frontend %q route restriction network %q parse error: %v", name, restriction.Network, err)
 						return
 					}
 				}
@@ -184,7 +184,7 @@ func (a *App) Fork(cfg *Config) (an *App, err error) {
 		}
 		fn, err = f.Fork(opts)
 		if err != nil {
-			err = errors.Errorf("frontend %q error: %v", name, err)
+			err = fmt.Errorf("frontend %q error: %v", name, err)
 			return
 		}
 		an.frontends[name] = fn
@@ -193,11 +193,11 @@ func (a *App) Fork(cfg *Config) (an *App, err error) {
 		for _, lItem := range item.Listeners {
 			address := lItem.Address
 			if address == "" {
-				err = errors.Errorf("frontend %q listener %q has not a valid address", name, address)
+				err = fmt.Errorf("frontend %q listener %q has not a valid address", name, address)
 				return
 			}
 			if _, ok := an.listeners[address]; ok {
-				err = errors.Errorf("frontend %q listener %q already defined", name, address)
+				err = fmt.Errorf("frontend %q listener %q already defined", name, address)
 				return
 			}
 			var opts lb.ListenerOptions
@@ -210,12 +210,12 @@ func (a *App) Fork(cfg *Config) (an *App, err error) {
 					tlsParams = cfg.Defaults.TLSParams
 				}
 				if tlsParams == nil {
-					err = errors.Errorf("frontend %q listener %q needs TLSParams", name, address)
+					err = fmt.Errorf("frontend %q listener %q needs TLSParams", name, address)
 					return
 				}
 				opts.TLSConfig, err = tlsParams.Config()
 				if err != nil {
-					err = errors.Errorf("frontend %q listener %q tls error: %v", name, address, err)
+					err = fmt.Errorf("frontend %q listener %q tls error: %v", name, address, err)
 					return
 				}
 			}
@@ -226,7 +226,7 @@ func (a *App) Fork(cfg *Config) (an *App, err error) {
 			}
 			ln, err = l.Fork(opts)
 			if err != nil {
-				err = errors.Errorf("frontend %q listener %q error: %v", name, address, err)
+				err = fmt.Errorf("frontend %q listener %q error: %v", name, address, err)
 				return
 			}
 			an.listeners[address] = ln

--- a/pkg/config/app.go
+++ b/pkg/config/app.go
@@ -59,6 +59,10 @@ func (a *App) Fork(cfg *Config) (an *App, err error) {
 				err = errors.Errorf("healthcheck %q another healthcheck defined", name)
 				return
 			}
+			respBody := []byte(nil)
+			if item.HTTP.Resp != "" {
+				respBody = []byte(item.HTTP.Resp)
+			}
 			h = &hc.HTTPCheckOptions{
 				Path:          item.HTTP.Path,
 				HeaderHost:    item.HTTP.Host,
@@ -66,7 +70,8 @@ func (a *App) Fork(cfg *Config) (an *App, err error) {
 				Timeout:       item.HTTP.Timeout,
 				FallThreshold: item.HTTP.Fall,
 				RiseThreshold: item.HTTP.Rise,
-				RespBody:      []byte(item.HTTP.Resp),
+				RespBody:      respBody,
+				UserAgent:     "simult-server/0.1 healthcheck",
 			}
 		}
 		an.healthChecks[name] = h

--- a/pkg/config/app.go
+++ b/pkg/config/app.go
@@ -203,7 +203,7 @@ func (a *App) Fork(cfg *Config) (an *App, err error) {
 			var opts lb.ListenerOptions
 			opts.Network = "tcp"
 			opts.Address = address
-			opts.Handler = fn
+			opts.Fe = fn
 			if lItem.TLS {
 				tlsParams := lItem.TLSParams
 				if tlsParams == nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -67,6 +67,7 @@ func LoadFrom(r io.Reader) (cfg *Config, err error) {
 	return
 }
 
+// LoadFromFile takes opened yaml file as input, decodes and returns as Config type
 func LoadFromFile(fileName string) (cfg *Config, err error) {
 	f, err := os.Open(fileName)
 	if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,13 +1,13 @@
 package config
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"regexp"
 	"sync/atomic"
 	"time"
 
-	"github.com/pkg/errors"
 	yaml "gopkg.in/yaml.v3"
 )
 
@@ -61,7 +61,7 @@ func LoadFrom(r io.Reader) (cfg *Config, err error) {
 	d := yaml.NewDecoder(r)
 	err = d.Decode(cfg)
 	if err != nil {
-		err = errors.WithStack(err)
+		err = fmt.Errorf("yaml decode error: %w", err)
 		return
 	}
 	return
@@ -71,7 +71,7 @@ func LoadFrom(r io.Reader) (cfg *Config, err error) {
 func LoadFromFile(fileName string) (cfg *Config, err error) {
 	f, err := os.Open(fileName)
 	if err != nil {
-		err = errors.WithStack(err)
+		err = fmt.Errorf("file %q open error: %w", fileName, err)
 		return
 	}
 	defer f.Close()

--- a/pkg/hc/httpcheck.go
+++ b/pkg/hc/httpcheck.go
@@ -17,6 +17,7 @@ type HTTPCheckOptions struct {
 	Interval, Timeout            time.Duration
 	FallThreshold, RiseThreshold int
 	RespBody                     []byte
+	UserAgent                    string
 }
 
 func (o *HTTPCheckOptions) CopyFrom(src *HTTPCheckOptions) {
@@ -123,6 +124,11 @@ func (h *HTTPCheck) check(ctx context.Context) (ok bool, err error) {
 	ctx, cancel := context.WithTimeout(ctx, h.opts.Timeout)
 	defer cancel()
 	req = req.WithContext(ctx)
+	userAgent := "healthcheck"
+	if h.opts.UserAgent != "" {
+		userAgent = h.opts.UserAgent
+	}
+	req.Header.Set("User-Agent", userAgent)
 	resp, err := h.client.Do(req)
 	if err != nil {
 		return

--- a/pkg/hc/httpcheck_test.go
+++ b/pkg/hc/httpcheck_test.go
@@ -27,8 +27,8 @@ func runSimpleHTTPServer() {
 
 func TestHTTPCheck(t *testing.T) {
 	go runSimpleHTTPServer()
-	opts := HTTPCheckOptions{"/healthcheck", "", 1 * time.Second, 1 * time.Second, 3, 2, []byte("UP")}
-	h, _ := NewHTTPCheck("http://127.0.0.1:4040", opts)
+	opts := HTTPCheckOptions{"/healthcheck", "", 1 * time.Second, 1 * time.Second, 3, 2, []byte("UP"), ""}
+	h := NewHTTPCheck("http://127.0.0.1:4040", opts)
 	defer h.Close()
 	for i := 0; i < 5; i++ {
 		r := <-h.Check()

--- a/pkg/lb/accepterhandler.go
+++ b/pkg/lb/accepterhandler.go
@@ -5,38 +5,37 @@ import (
 	"crypto/tls"
 	"net"
 	"sync"
-
-	accepter "github.com/orkunkaraduman/go-accepter"
 )
 
 type accepterHandler struct {
-	Lis net.Listener
-
 	mu        sync.RWMutex
-	handler   accepter.Handler
+	le        *Listener
+	fe        Frontend
 	tlsConfig *tls.Config
 
 	shared   bool
 	sharedMu sync.Mutex
 }
 
-func (ah *accepterHandler) Set(handler accepter.Handler, tlsConfig *tls.Config) {
+func (ah *accepterHandler) Set(le *Listener, fe Frontend, tlsConfig *tls.Config) {
 	ah.mu.Lock()
-	ah.handler = handler
+	ah.le = le
+	ah.fe = fe
 	ah.tlsConfig = tlsConfig
 	ah.mu.Unlock()
 }
 
 func (ah *accepterHandler) Serve(ctx context.Context, conn net.Conn) {
 	ah.mu.RLock()
-	handler := ah.handler
+	le := ah.le
+	fe := ah.fe
 	tlsConfig := ah.tlsConfig
 	ah.mu.RUnlock()
-	if handler != nil {
+	if fe != nil {
 		if tlsConfig != nil {
 			conn = tls.Server(conn, tlsConfig)
 		}
-		handler.Serve(ctx, conn)
+		fe.Serve(ctx, le, conn)
 	}
 }
 

--- a/pkg/lb/accepterhandler.go
+++ b/pkg/lb/accepterhandler.go
@@ -35,7 +35,9 @@ func (ah *accepterHandler) Serve(ctx context.Context, conn net.Conn) {
 		if tlsConfig != nil {
 			conn = tls.Server(conn, tlsConfig)
 		}
+		le.promConnections.With(nil).Inc()
 		fe.Serve(ctx, le, conn)
+		le.promConnections.With(nil).Dec()
 	}
 }
 

--- a/pkg/lb/backendserver.go
+++ b/pkg/lb/backendserver.go
@@ -3,12 +3,13 @@ package lb
 import (
 	"context"
 	"crypto/tls"
+	"errors"
+	"fmt"
 	"net"
 	"net/url"
 	"sync"
 	"sync/atomic"
 
-	"github.com/pkg/errors"
 	"github.com/simult/server/pkg/hc"
 )
 
@@ -41,7 +42,7 @@ func newBackendServer(server string) (bs *backendServer, err error) {
 	var useTLS bool
 	serverURL, err = url.Parse(server)
 	if err != nil {
-		err = errors.WithStack(err)
+		err = fmt.Errorf("server url parse error: %w", err)
 		return
 	}
 	if serverURL.Host == "" {
@@ -155,7 +156,6 @@ func (bs *backendServer) ConnAcquire(ctx context.Context) (bc *bufConn, err erro
 		var conn net.Conn
 		conn, err = backendDialer.DialContext(ctx, "tcp", bs.address)
 		if err != nil {
-			err = errors.WithStack(err)
 			return
 		}
 		if bs.useTLS {

--- a/pkg/lb/frontend.go
+++ b/pkg/lb/frontend.go
@@ -6,5 +6,5 @@ import (
 )
 
 type Frontend interface {
-	Serve(ctx context.Context, le *Listener, conn net.Conn)
+	Serve(ctx context.Context, l *Listener, conn net.Conn)
 }

--- a/pkg/lb/frontend.go
+++ b/pkg/lb/frontend.go
@@ -1,0 +1,10 @@
+package lb
+
+import (
+	"context"
+	"net"
+)
+
+type Frontend interface {
+	Serve(ctx context.Context, le *Listener, conn net.Conn)
+}

--- a/pkg/lb/httpbackend.go
+++ b/pkg/lb/httpbackend.go
@@ -349,7 +349,7 @@ func (b *HTTPBackend) serveAsync(ctx context.Context, errCh chan<- error, reqDes
 func (b *HTTPBackend) serve(ctx context.Context, reqDesc *httpReqDesc) (err error) {
 	bs := b.findServer(ctx)
 	if bs == nil {
-		err = wrapHTTPError("backend", errUnableToFindBackendServer)
+		err = wrapHTTPError("backend find", errUnableToFindBackendServer)
 		debugLogger.Printf("serve error on %s: %v", reqDesc.BackendSummary(), err)
 		reqDesc.feConn.Write([]byte(httpServiceUnavailable))
 		return
@@ -358,7 +358,7 @@ func (b *HTTPBackend) serve(ctx context.Context, reqDesc *httpReqDesc) (err erro
 
 	reqDesc.beConn, err = bs.ConnAcquire(ctx)
 	if err != nil {
-		err = wrapHTTPError("backend", errCouldNotConnectToBackendServer)
+		err = wrapHTTPError("backend connect", errCouldNotConnectToBackendServer)
 		debugLogger.Printf("serve error on %s: %v", reqDesc.BackendSummary(), err)
 		reqDesc.feConn.Write([]byte(httpBadGateway))
 		return

--- a/pkg/lb/httpbackend.go
+++ b/pkg/lb/httpbackend.go
@@ -76,9 +76,25 @@ func (b *HTTPBackend) Fork(opts HTTPBackendOptions) (bn *HTTPBackend, err error)
 	promLabels := map[string]string{
 		"backend": bn.opts.Name,
 	}
+	promLabels2 := prometheus.Labels{
+		"server":   "",
+		"code":     "",
+		"frontend": "",
+		"address":  "",
+		"host":     "",
+		"path":     "",
+		"method":   "",
+	}
+
 	bn.promReadBytes = promHTTPBackendReadBytes.MustCurryWith(promLabels)
+	bn.promReadBytes.With(promLabels2).Add(0)
+
 	bn.promWriteBytes = promHTTPBackendWriteBytes.MustCurryWith(promLabels)
+	bn.promWriteBytes.With(promLabels2).Add(0)
+
 	bn.promRequestsTotal = promHTTPBackendRequestsTotal.MustCurryWith(promLabels)
+	bn.promRequestsTotal.With(promLabels2).Add(0)
+
 	bn.promRequestDurationSeconds = promHTTPBackendRequestDurationSeconds.MustCurryWith(promLabels)
 	bn.promTimeToFirstByteSeconds = promHTTPBackendTimeToFirstByteSeconds.MustCurryWith(promLabels)
 	bn.promActiveConnections = promHTTPBackendActiveConnections.MustCurryWith(promLabels)

--- a/pkg/lb/httpbackend.go
+++ b/pkg/lb/httpbackend.go
@@ -73,7 +73,7 @@ func (b *HTTPBackend) Fork(opts HTTPBackendOptions) (bn *HTTPBackend, err error)
 	bn.bss = make(map[string]*backendServer, len(opts.Servers))
 	bn.rnd = rand.New(rand.NewSource(time.Now().Unix()))
 
-	promLabels := map[string]string{
+	promLabels := prometheus.Labels{
 		"backend": bn.opts.Name,
 	}
 	promLabelsEmpty := prometheus.Labels{
@@ -99,8 +99,6 @@ func (b *HTTPBackend) Fork(opts HTTPBackendOptions) (bn *HTTPBackend, err error)
 	bn.promTimeToFirstByteSeconds = promHTTPBackendTimeToFirstByteSeconds.MustCurryWith(promLabels)
 	bn.promActiveConnections = promHTTPBackendActiveConnections.MustCurryWith(promLabels)
 	bn.promServerHealthy = promHTTPBackendServerHealthy.MustCurryWith(promLabels)
-
-	bn.updateBssList()
 
 	defer func() {
 		if err == nil {
@@ -141,6 +139,9 @@ func (b *HTTPBackend) Fork(opts HTTPBackendOptions) (bn *HTTPBackend, err error)
 	for _, bsr := range bn.bss {
 		bn.opts.Servers = append(bn.opts.Servers, bsr.server)
 	}
+
+	bn.updateBssList()
+
 	return
 }
 

--- a/pkg/lb/httpbackend.go
+++ b/pkg/lb/httpbackend.go
@@ -278,7 +278,7 @@ func (b *HTTPBackend) serveEngress(ctx context.Context, errCh chan<- error, reqD
 
 		_, err = writeHTTPHeader(reqDesc.feConn.Writer, reqDesc.beStatusLine, reqDesc.beHdr)
 		if err != nil {
-			debugLogger.Printf("serve error on %s: write header to backend: %v", reqDesc.BackendSummary(), err)
+			debugLogger.Printf("serve error on %s: write header to frontend: %v", reqDesc.BackendSummary(), err)
 			return
 		}
 

--- a/pkg/lb/httpbackend.go
+++ b/pkg/lb/httpbackend.go
@@ -263,7 +263,7 @@ func (b *HTTPBackend) serveEngress(ctx context.Context, errCh chan<- error, reqD
 		}
 		beStatusLineParts := strings.SplitN(reqDesc.beStatusLine, " ", 3)
 		if len(beStatusLineParts) < 3 {
-			err = wrapHTTPError("protocol", errHTTPStatusLineFormat)
+			err = errHTTPStatusLineFormat
 			debugLogger.Printf("serve error on %s: read header from backend: %v", reqDesc.BackendSummary(), err)
 			return
 		}
@@ -271,7 +271,7 @@ func (b *HTTPBackend) serveEngress(ctx context.Context, errCh chan<- error, reqD
 		reqDesc.beStatusCode = beStatusLineParts[1]
 		reqDesc.beStatusMsg = beStatusLineParts[2]
 		if reqDesc.beStatusVersion != "HTTP/1.0" && reqDesc.beStatusVersion != "HTTP/1.1" {
-			err = wrapHTTPError("protocol", errHTTPVersion)
+			err = errHTTPVersion
 			debugLogger.Printf("serve error on %s: read header from backend: %v", reqDesc.BackendSummary(), err)
 			return
 		}
@@ -331,7 +331,7 @@ func (b *HTTPBackend) serveAsync(ctx context.Context, errCh chan<- error, reqDes
 	}
 
 	if reqDesc.beConn.Reader.Buffered() != 0 {
-		err = wrapHTTPError("protocol", errHTTPBufferOrder)
+		err = errHTTPBufferOrder
 		debugLogger.Printf("serve error on %s: %v", reqDesc.BackendSummary(), err)
 		return
 	}
@@ -349,7 +349,7 @@ func (b *HTTPBackend) serveAsync(ctx context.Context, errCh chan<- error, reqDes
 func (b *HTTPBackend) serve(ctx context.Context, reqDesc *httpReqDesc) (err error) {
 	bs := b.findServer(ctx)
 	if bs == nil {
-		err = wrapHTTPError("backend find", errUnableToFindBackendServer)
+		err = errHTTPUnableToFindBackendServer
 		debugLogger.Printf("serve error on %s: %v", reqDesc.BackendSummary(), err)
 		reqDesc.feConn.Write([]byte(httpServiceUnavailable))
 		return
@@ -358,7 +358,7 @@ func (b *HTTPBackend) serve(ctx context.Context, reqDesc *httpReqDesc) (err erro
 
 	reqDesc.beConn, err = bs.ConnAcquire(ctx)
 	if err != nil {
-		err = wrapHTTPError("backend connect", errCouldNotConnectToBackendServer)
+		err = errHTTPCouldNotConnectToBackendServer
 		debugLogger.Printf("serve error on %s: %v", reqDesc.BackendSummary(), err)
 		reqDesc.feConn.Write([]byte(httpBadGateway))
 		return
@@ -433,7 +433,7 @@ func (b *HTTPBackend) serve(ctx context.Context, reqDesc *httpReqDesc) (err erro
 		reqDesc.beConn.Flush()
 		reqDesc.beConn.Close()
 		<-asyncErrCh
-		err = wrapHTTPError("backend timeout", errHTTPTimeout)
+		err = errHTTPBackendTimeout
 		debugLogger.Printf("serve error on %s: %v", reqDesc.BackendSummary(), err)
 	case err = <-asyncErrCh:
 		if err != nil {

--- a/pkg/lb/httpcommon.go
+++ b/pkg/lb/httpcommon.go
@@ -21,15 +21,16 @@ var (
 )
 
 var (
-	errHTTPChunkedTransferEncoding     = errors.New("chunked transfer encoding error")
-	errHTTPUnsupportedTransferEncoding = errors.New("unsupported transfer encoding")
-	errHTTPStatusLineFormat            = errors.New("status line format error")
-	errHTTPVersion                     = errors.New("HTTP version error")
-	errHTTPRestrictedRequest           = errors.New("restricted request")
-	errHTTPBufferOrder                 = errors.New("buffer order error")
-	errHTTPTimeout                     = errors.New("timeout exceeded")
-	errUnableToFindBackendServer       = errors.New("unable to find backend server")
-	errCouldNotConnectToBackendServer  = errors.New("could not connect to backend server")
+	errHTTPChunkedTransferEncoding        = newHTTPError("protocol", "chunked transfer encoding error")
+	errHTTPUnsupportedTransferEncoding    = newHTTPError("protocol", "unsupported transfer encoding")
+	errHTTPStatusLineFormat               = newHTTPError("protocol", "status line format error")
+	errHTTPVersion                        = newHTTPError("protocol", "HTTP version error")
+	errHTTPRestrictedRequest              = newHTTPError("restricted", "restricted request")
+	errHTTPBufferOrder                    = newHTTPError("protocol", "buffer order error")
+	errHTTPFrontendTimeout                = newHTTPError("frontend timeout", "timeout exceeded")
+	errHTTPBackendTimeout                 = newHTTPError("backend timeout", "timeout exceeded")
+	errHTTPUnableToFindBackendServer      = newHTTPError("backend find", "unable to find backend server")
+	errHTTPCouldNotConnectToBackendServer = newHTTPError("backend connect", "could not connect to backend server")
 )
 
 type httpError struct {
@@ -239,7 +240,7 @@ func writeHTTPBody(dst io.Writer, src *bufio.Reader, contentLength int64, transf
 		}
 		if n <= 0 || string(crlfBuf[:n]) != "\r\n" {
 			nw = dstSW.N
-			err = wrapHTTPError("protocol", errHTTPChunkedTransferEncoding)
+			err = errHTTPChunkedTransferEncoding
 			break
 		}
 		_, err = dstSW.Write(crlfBuf[:n])
@@ -250,7 +251,7 @@ func writeHTTPBody(dst io.Writer, src *bufio.Reader, contentLength int64, transf
 		}
 		nw = dstSW.N
 	default:
-		err = wrapHTTPError("protocol", errHTTPUnsupportedTransferEncoding)
+		err = errHTTPUnsupportedTransferEncoding
 	}
 	if dstWr, ok := dst.(*bufio.Writer); ok {
 		if e := dstWr.Flush(); e != nil && err == nil {

--- a/pkg/lb/httpcommon.go
+++ b/pkg/lb/httpcommon.go
@@ -70,9 +70,9 @@ func (e *httpError) Unwrap() error {
 }
 
 type httpReqDesc struct {
+	leName          string
 	feName          string
 	feConn          *bufConn
-	feAddress       string
 	feStatusLine    string
 	feStatusMethod  string
 	feStatusURI     string
@@ -81,8 +81,7 @@ type httpReqDesc struct {
 	feHost          string
 	fePath          string
 	beName          string
-	beServer        *backendServer
-	beServerName    string
+	beServer        string
 	beConn          *bufConn
 	beStatusLine    string
 	beStatusVersion string
@@ -92,25 +91,25 @@ type httpReqDesc struct {
 }
 
 func (r *httpReqDesc) FrontendSummary() string {
-	return fmt.Sprintf("frontend=%q address=%q host=%q path=%q method=%q",
+	return fmt.Sprintf("frontend=%q host=%q path=%q method=%q listener=%q",
 		r.feName,
-		r.feAddress,
 		r.feHost,
 		r.fePath,
 		r.feStatusMethod,
+		r.leName,
 	)
 }
 
 func (r *httpReqDesc) BackendSummary() string {
-	return fmt.Sprintf("backend=%q server=%q code=%q frontend=%q address=%q host=%q path=%q method=%q",
+	return fmt.Sprintf("backend=%q server=%q code=%q frontend=%q host=%q path=%q method=%q listener=%q",
 		r.beName,
-		r.beServerName,
+		r.beServer,
 		r.beStatusCode,
 		r.feName,
-		r.feAddress,
 		r.feHost,
 		r.fePath,
 		r.feStatusMethod,
+		r.leName,
 	)
 }
 

--- a/pkg/lb/httpfrontend.go
+++ b/pkg/lb/httpfrontend.go
@@ -324,7 +324,7 @@ func (f *HTTPFrontend) serve(ctx context.Context, reqDesc *httpReqDesc) (err err
 	return
 }
 
-func (f *HTTPFrontend) Serve(ctx context.Context, conn net.Conn) {
+func (f *HTTPFrontend) Serve(ctx context.Context, le *Listener, conn net.Conn) {
 	if tcpConn, ok := conn.(*net.TCPConn); ok {
 		tcpConn.SetKeepAlive(true)
 		tcpConn.SetKeepAlivePeriod(1 * time.Second)

--- a/pkg/lb/httpfrontend.go
+++ b/pkg/lb/httpfrontend.go
@@ -232,7 +232,7 @@ func (f *HTTPFrontend) serveAsync(ctx context.Context, errCh chan<- error, reqDe
 	}
 	feStatusLineParts := strings.SplitN(reqDesc.feStatusLine, " ", 3)
 	if len(feStatusLineParts) < 3 {
-		err = wrapHTTPError("protocol", errHTTPStatusLineFormat)
+		err = errHTTPStatusLineFormat
 		debugLogger.Printf("serve error on %s: read header from frontend: %v", reqDesc.FrontendSummary(), err)
 		reqDesc.feConn.Write([]byte(httpBadRequest))
 		return
@@ -241,7 +241,7 @@ func (f *HTTPFrontend) serveAsync(ctx context.Context, errCh chan<- error, reqDe
 	reqDesc.feStatusURI = feStatusLineParts[1]
 	reqDesc.feStatusVersion = strings.ToUpper(feStatusLineParts[2])
 	if reqDesc.feStatusVersion != "HTTP/1.0" && reqDesc.feStatusVersion != "HTTP/1.1" {
-		err = wrapHTTPError("protocol", errHTTPVersion)
+		err = errHTTPVersion
 		debugLogger.Printf("serve error on %s: read header from frontend: %v", reqDesc.FrontendSummary(), err)
 		reqDesc.feConn.Write([]byte(httpVersionNotSupported))
 		return
@@ -249,7 +249,7 @@ func (f *HTTPFrontend) serveAsync(ctx context.Context, errCh chan<- error, reqDe
 
 	b := f.findBackend(reqDesc)
 	if b == nil {
-		err = wrapHTTPError("restricted", errHTTPRestrictedRequest)
+		err = errHTTPRestrictedRequest
 		debugLogger.Printf("serve error on %s: %v", reqDesc.FrontendSummary(), err)
 		reqDesc.feConn.Write([]byte(httpForbidden))
 		return
@@ -261,7 +261,7 @@ func (f *HTTPFrontend) serveAsync(ctx context.Context, errCh chan<- error, reqDe
 
 	// it can be happened when client has been started new request before ending request body transfer!
 	if reqDesc.feConn.Reader.Buffered() != 0 {
-		err = wrapHTTPError("protocol", errHTTPBufferOrder)
+		err = errHTTPBufferOrder
 		debugLogger.Printf("serve error on %s: %v", reqDesc.FrontendSummary(), err)
 		return
 	}
@@ -284,7 +284,7 @@ func (f *HTTPFrontend) serve(ctx context.Context, reqDesc *httpReqDesc) (err err
 		reqDesc.feConn.Flush()
 		reqDesc.feConn.Close()
 		<-asyncErrCh
-		err = wrapHTTPError("frontend timeout", errHTTPTimeout)
+		err = errHTTPFrontendTimeout
 		debugLogger.Printf("serve error on %s: %v", reqDesc.FrontendSummary(), err)
 	case err = <-asyncErrCh:
 		if err != nil {

--- a/pkg/lb/httpfrontend.go
+++ b/pkg/lb/httpfrontend.go
@@ -108,9 +108,25 @@ func (f *HTTPFrontend) Fork(opts HTTPFrontendOptions) (fn *HTTPFrontend, err err
 	promLabels := map[string]string{
 		"frontend": fn.opts.Name,
 	}
+	promLabels2 := prometheus.Labels{
+		"address": "",
+		"host":    "",
+		"path":    "",
+		"method":  "",
+		"backend": "",
+		"server":  "",
+		"code":    "",
+	}
+
 	fn.promReadBytes = promHTTPFrontendReadBytes.MustCurryWith(promLabels)
+	fn.promReadBytes.With(promLabels2).Add(0)
+
 	fn.promWriteBytes = promHTTPFrontendWriteBytes.MustCurryWith(promLabels)
+	fn.promWriteBytes.With(promLabels2).Add(0)
+
 	fn.promRequestsTotal = promHTTPFrontendRequestsTotal.MustCurryWith(promLabels)
+	fn.promRequestsTotal.With(promLabels2).Add(0)
+
 	fn.promRequestDurationSeconds = promHTTPFrontendRequestDurationSeconds.MustCurryWith(promLabels)
 	fn.promActiveConnections = promHTTPFrontendActiveConnections.MustCurryWith(promLabels)
 	fn.promIdleConnections = promHTTPFrontendIdleConnections.MustCurryWith(promLabels)

--- a/pkg/lb/httpfrontend.go
+++ b/pkg/lb/httpfrontend.go
@@ -104,7 +104,7 @@ func (f *HTTPFrontend) Fork(opts HTTPFrontendOptions) (fn *HTTPFrontend, err err
 	fn.workerWg.Add(1)
 	go fn.worker(fn.workerCtx)
 
-	promLabels := map[string]string{
+	promLabels := prometheus.Labels{
 		"frontend": fn.opts.Name,
 	}
 	promLabelsEmpty := prometheus.Labels{

--- a/pkg/lb/lb.go
+++ b/pkg/lb/lb.go
@@ -1,18 +1,13 @@
 package lb
 
 import (
+	"errors"
 	"regexp"
-
-	"github.com/pkg/errors"
 )
 
 const (
 	maxHTTPHeaderLineLen = 1 * 1024 * 1024
 	maxHTTPHeadersLen    = 10 * 1024 * 1024
-)
-
-var (
-	errProtocol = errors.New("protocol error")
 )
 
 var (

--- a/pkg/lb/listener.go
+++ b/pkg/lb/listener.go
@@ -3,12 +3,12 @@ package lb
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"net"
 	"sync"
 	"time"
 
 	accepter "github.com/orkunkaraduman/go-accepter"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -70,7 +70,6 @@ func (l *Listener) Fork(opts ListenerOptions) (ln *Listener, err error) {
 		var lis net.Listener
 		lis, err = net.Listen(ln.opts.Network, ln.opts.Address)
 		if err != nil {
-			err = errors.WithStack(err)
 			return
 		}
 		ln.accr = &accepter.Accepter{

--- a/pkg/lb/listener.go
+++ b/pkg/lb/listener.go
@@ -85,7 +85,7 @@ func (l *Listener) Fork(opts ListenerOptions) (ln *Listener, err error) {
 					select {
 					case <-time.After(100 * time.Millisecond):
 						last := accr.TemporaryErrorCount
-						if v := float64(last - first); v > 0 {
+						if v := float64(last - first); v >= 0 {
 							promTemporaryErrorsTotal.With(nil).Add(v)
 						}
 						first = last

--- a/pkg/lb/listener.go
+++ b/pkg/lb/listener.go
@@ -1,12 +1,10 @@
 package lb
 
 import (
-	"context"
 	"crypto/tls"
 	"errors"
 	"net"
 	"sync"
-	"time"
 
 	accepter "github.com/orkunkaraduman/go-accepter"
 	"github.com/prometheus/client_golang/prometheus"
@@ -25,10 +23,10 @@ func (o *ListenerOptions) CopyFrom(src *ListenerOptions) {
 }
 
 type Listener struct {
-	opts                     ListenerOptions
-	accr                     *accepter.Accepter
-	accrMu                   sync.RWMutex
-	promTemporaryErrorsTotal *prometheus.CounterVec
+	opts            ListenerOptions
+	accr            *accepter.Accepter
+	accrMu          sync.RWMutex
+	promConnections *prometheus.GaugeVec
 }
 
 func NewListener(opts ListenerOptions) (l *Listener, err error) {
@@ -39,12 +37,6 @@ func NewListener(opts ListenerOptions) (l *Listener, err error) {
 func (l *Listener) Fork(opts ListenerOptions) (ln *Listener, err error) {
 	ln = &Listener{}
 	ln.opts.CopyFrom(&opts)
-
-	promLabels := map[string]string{
-		"network": ln.opts.Network,
-		"address": ln.opts.Address,
-	}
-	ln.promTemporaryErrorsTotal = promListenerTemporaryErrorsTotal.MustCurryWith(promLabels)
 
 	defer func() {
 		if err == nil {
@@ -64,40 +56,31 @@ func (l *Listener) Fork(opts ListenerOptions) (ln *Listener, err error) {
 		ln.opts.Network = l.opts.Network
 		ln.opts.Address = l.opts.Address
 		ln.accr = l.accr
-		ln.promTemporaryErrorsTotal = l.promTemporaryErrorsTotal
+		ln.promConnections = l.promConnections
+		return
 	}
 
-	if ln.accr == nil {
-		var lis net.Listener
-		lis, err = net.Listen(ln.opts.Network, ln.opts.Address)
-		if err != nil {
-			return
-		}
-		ln.accr = &accepter.Accepter{
-			Handler: &accepterHandler{},
-		}
-		go func(lis net.Listener, opts ListenerOptions, accr *accepter.Accepter, promTemporaryErrorsTotal *prometheus.CounterVec) {
-			serveCtx, serveCtxCancel := context.WithCancel(context.Background())
-			go func() {
-				for done, first := false, accr.TemporaryErrorCount; !done; {
-					select {
-					case <-time.After(100 * time.Millisecond):
-						last := accr.TemporaryErrorCount
-						if v := float64(last - first); v >= 0 {
-							promTemporaryErrorsTotal.With(nil).Add(v)
-						}
-						first = last
-					case <-serveCtx.Done():
-						done = true
-					}
-				}
-			}()
-			if e := accr.Serve(lis); e != nil {
-				errorLogger.Printf("listener %q serve error: %v", opts.Name, e)
-			}
-			serveCtxCancel()
-		}(lis, ln.opts, ln.accr, ln.promTemporaryErrorsTotal)
+	var lis net.Listener
+	lis, err = net.Listen(ln.opts.Network, ln.opts.Address)
+	if err != nil {
+		return
 	}
+	ln.accr = &accepter.Accepter{
+		Handler: &accepterHandler{},
+	}
+
+	promLabels := prometheus.Labels{
+		"listener": ln.opts.Name,
+		"network":  ln.opts.Network,
+		"address":  ln.opts.Address,
+	}
+	ln.promConnections = promListenerConnections.MustCurryWith(promLabels)
+
+	go func(lis net.Listener, opts ListenerOptions, accr *accepter.Accepter) {
+		if e := accr.Serve(lis); e != nil {
+			errorLogger.Printf("listener %q serve error: %v", opts.Name, e)
+		}
+	}(lis, ln.opts, ln.accr)
 
 	return
 }

--- a/pkg/lb/listener.go
+++ b/pkg/lb/listener.go
@@ -13,6 +13,7 @@ import (
 )
 
 type ListenerOptions struct {
+	Name      string
 	Network   string
 	Address   string
 	Fe        Frontend
@@ -92,7 +93,7 @@ func (l *Listener) Fork(opts ListenerOptions) (ln *Listener, err error) {
 				}
 			}()
 			if e := accr.Serve(lis); e != nil {
-				errorLogger.Printf("listener %q serve error: %v", opts.Network+"://"+opts.Address, e)
+				errorLogger.Printf("listener %q serve error: %v", opts.Name, e)
 			}
 			serveCtxCancel()
 		}(lis, ln.opts, ln.accr, ln.promTemporaryErrorsTotal)

--- a/pkg/lb/prom.go
+++ b/pkg/lb/prom.go
@@ -41,70 +41,70 @@ func PromInitialize(namespace string) {
 		Namespace: namespace,
 		Subsystem: "http_frontend",
 		Name:      "read_bytes",
-	}, []string{"frontend", "address", "host", "path", "method", "backend", "server", "code"})
+	}, []string{"frontend", "host", "path", "method", "backend", "server", "code", "listener"})
 
 	promHTTPFrontendWriteBytes = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: namespace,
 		Subsystem: "http_frontend",
 		Name:      "write_bytes",
-	}, []string{"frontend", "address", "host", "path", "method", "backend", "server", "code"})
+	}, []string{"frontend", "host", "path", "method", "backend", "server", "code", "listener"})
 
 	promHTTPFrontendRequestsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: namespace,
 		Subsystem: "http_frontend",
 		Name:      "requests_total",
-	}, []string{"frontend", "address", "host", "path", "method", "backend", "server", "code", "error"})
+	}, []string{"frontend", "host", "path", "method", "backend", "server", "code", "listener", "error"})
 
 	promHTTPFrontendRequestDurationSeconds = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: namespace,
 		Subsystem: "http_frontend",
 		Name:      "request_duration_seconds",
 		Buckets:   histogramBuckets,
-	}, []string{"frontend", "address", "host", "path", "method", "backend", "server", "code"})
+	}, []string{"frontend", "host", "path", "method", "backend", "server", "code", "listener"})
 
 	promHTTPFrontendActiveConnections = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: namespace,
 		Subsystem: "http_frontend",
 		Name:      "active_connections",
-	}, []string{"frontend", "address"})
+	}, []string{"frontend", "listener"})
 
 	promHTTPFrontendIdleConnections = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: namespace,
 		Subsystem: "http_frontend",
 		Name:      "idle_connections",
-	}, []string{"frontend", "address"})
+	}, []string{"frontend", "listener"})
 
 	promHTTPBackendReadBytes = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: namespace,
 		Subsystem: "http_backend",
 		Name:      "read_bytes",
-	}, []string{"backend", "server", "code", "frontend", "address", "host", "path", "method"})
+	}, []string{"backend", "server", "code", "frontend", "host", "path", "method", "listener"})
 
 	promHTTPBackendWriteBytes = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: namespace,
 		Subsystem: "http_backend",
 		Name:      "write_bytes",
-	}, []string{"backend", "server", "code", "frontend", "address", "host", "path", "method"})
+	}, []string{"backend", "server", "code", "frontend", "host", "path", "method", "listener"})
 
 	promHTTPBackendRequestsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: namespace,
 		Subsystem: "http_backend",
 		Name:      "requests_total",
-	}, []string{"backend", "server", "code", "frontend", "address", "host", "path", "method", "error"})
+	}, []string{"backend", "server", "code", "frontend", "host", "path", "method", "listener", "error"})
 
 	promHTTPBackendRequestDurationSeconds = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: namespace,
 		Subsystem: "http_backend",
 		Name:      "request_duration_seconds",
 		Buckets:   histogramBuckets,
-	}, []string{"backend", "server", "code", "frontend", "address", "host", "path", "method"})
+	}, []string{"backend", "server", "code", "frontend", "host", "path", "method", "listener"})
 
 	promHTTPBackendTimeToFirstByteSeconds = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: namespace,
 		Subsystem: "http_backend",
 		Name:      "time_to_first_byte_seconds",
 		Buckets:   histogramBuckets,
-	}, []string{"backend", "server", "code", "frontend", "address", "host", "path", "method"})
+	}, []string{"backend", "server", "code", "frontend", "host", "path", "method", "listener"})
 
 	promHTTPBackendActiveConnections = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: namespace,

--- a/pkg/lb/prom.go
+++ b/pkg/lb/prom.go
@@ -22,7 +22,7 @@ var (
 	promHTTPBackendTimeToFirstByteSeconds  *prometheus.HistogramVec
 	promHTTPBackendActiveConnections       *prometheus.GaugeVec
 	promHTTPBackendServerHealthy           *prometheus.GaugeVec
-	promListenerTemporaryErrorsTotal       *prometheus.CounterVec
+	promListenerConnections                *prometheus.GaugeVec
 )
 
 func PromInitialize(namespace string) {
@@ -118,11 +118,11 @@ func PromInitialize(namespace string) {
 		Name:      "server_healthy",
 	}, []string{"backend", "server"})
 
-	promListenerTemporaryErrorsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	promListenerConnections = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: namespace,
 		Subsystem: "listener",
-		Name:      "temporary_errors_total",
-	}, []string{"network", "address"})
+		Name:      "connections",
+	}, []string{"listener", "network", "address"})
 }
 
 func PromReset() {
@@ -139,5 +139,5 @@ func PromReset() {
 	promHTTPBackendTimeToFirstByteSeconds.Reset()
 	//promHTTPBackendActiveConnections.Reset()
 	//promHTTPBackendServerHealthy.Reset()
-	promListenerTemporaryErrorsTotal.Reset()
+	//promListenerConnections.Reset()
 }


### PR DESCRIPTION
- removed promTemporaryErrorsTotal metric
- added promListenerConnections metric
- added http health-check user-agent
- initialized some metrics for grafana variables
- removed all definitions of github.com/pkg/errors
- implemented by go 1.13
- summarized http errors
- added Frontend interface
- added name to Listener
- bugfix: x-forwarded-for address
- bugfix: http user-agent
